### PR TITLE
updated swagger-core version to fix issue with casting a BooleanNode …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.wordnik</groupId>
+            <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
-            <version>1.5.3-M1</version>
+            <version>1.5.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…to a TextNode (https://github.com/swagger-api/swagger-core/issues/1112)

I was receiving an error:

```
com.fasterxml.jackson.databind.node.BooleanNode cannot be cast to com.fasterxml.jackson.databind.node.TextNode (through reference chain: com.wordnik.swagger.models.ModelImpl["properties"]->java.util.LinkedHashMap["hasAvailableEpisode"]) (through reference chain: com.wordnik.swagger.models.Swagger["definitions"]->java.util.LinkedHashMap["Show"])
```

which was fixed with the released version 1.5.0.  So, please upgrade to 1.5.0 to fix this issue.
