### PR TITLE
Updating all references to old swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
 
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-compat-spec-parser</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.8</version>
         </dependency>
 
         <dependency>

--- a/src/com/amazonaws/service/apigateway/importer/SwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/SwaggerApiImporter.java
@@ -14,7 +14,8 @@
  */
 package com.amazonaws.service.apigateway.importer;
 
-import com.wordnik.swagger.models.Swagger;
+
+import io.swagger.models.Swagger;
 
 public interface SwaggerApiImporter {
     String createApi(Swagger swagger, String name);

--- a/src/com/amazonaws/service/apigateway/importer/impl/ApiGatewaySwaggerFileImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/ApiGatewaySwaggerFileImporter.java
@@ -17,7 +17,7 @@ package com.amazonaws.service.apigateway.importer.impl;
 import com.amazonaws.service.apigateway.importer.ApiFileImporter;
 import com.amazonaws.service.apigateway.importer.SwaggerApiImporter;
 import com.google.inject.Inject;
-import com.wordnik.swagger.models.Swagger;
+import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
@@ -34,17 +34,17 @@ import com.amazonaws.services.apigateway.model.PutMethodResponseInput;
 import com.amazonaws.services.apigateway.model.Resource;
 import com.amazonaws.services.apigateway.model.RestApi;
 import com.google.inject.Inject;
-import com.wordnik.swagger.models.Operation;
-import com.wordnik.swagger.models.Path;
-import com.wordnik.swagger.models.RefModel;
-import com.wordnik.swagger.models.Response;
-import com.wordnik.swagger.models.Swagger;
-import com.wordnik.swagger.models.auth.SecuritySchemeDefinition;
-import com.wordnik.swagger.models.parameters.BodyParameter;
-import com.wordnik.swagger.models.parameters.Parameter;
-import com.wordnik.swagger.models.properties.Property;
-import com.wordnik.swagger.models.properties.RefProperty;
-import com.wordnik.swagger.util.Json;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.RefModel;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.util.Json;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -261,20 +261,20 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         }
     }
 
-    private void createModels(RestApi api, Map<String, com.wordnik.swagger.models.Model> definitions, List<String> produces) {
+    private void createModels(RestApi api, Map<String, io.swagger.models.Model> definitions, List<String> produces) {
         if (definitions == null) {
             return;
         }
 
-        for (Map.Entry<String, com.wordnik.swagger.models.Model> entry : definitions.entrySet()) {
+        for (Map.Entry<String, io.swagger.models.Model> entry : definitions.entrySet()) {
             final String modelName = entry.getKey();
-            final com.wordnik.swagger.models.Model model = entry.getValue();
+            final io.swagger.models.Model model = entry.getValue();
 
             createModel(api, modelName, model, definitions, getProducesContentType(produces, emptyList()));
         }
     }
 
-    private void createModel(RestApi api, String modelName, com.wordnik.swagger.models.Model model, Map<String, com.wordnik.swagger.models.Model> definitions, String modelContentType) {
+    private void createModel(RestApi api, String modelName, io.swagger.models.Model model, Map<String, io.swagger.models.Model> definitions, String modelContentType) {
         LOG.info(format("Creating model for api id %s with name %s", api.getId(), modelName));
 
         createModel(api, modelName, model.getDescription(), generateSchema(model, modelName, definitions), modelContentType);
@@ -470,11 +470,11 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         return false;
     }
 
-    private String generateSchema(Property model, String modelName, Map<String, com.wordnik.swagger.models.Model> definitions) {
+    private String generateSchema(Property model, String modelName, Map<String, io.swagger.models.Model> definitions) {
         return generateSchemaString(model, modelName, definitions);
     }
 
-    private String generateSchemaString(Object model, String modelName, Map<String, com.wordnik.swagger.models.Model> definitions) {
+    private String generateSchemaString(Object model, String modelName, Map<String, io.swagger.models.Model> definitions) {
         try {
             String modelSchema = Json.mapper().writeValueAsString(model);
             String models = Json.mapper().writeValueAsString(definitions);
@@ -490,12 +490,12 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         }
     }
 
-    private String generateSchema(com.wordnik.swagger.models.Model model, String modelName, Map<String, com.wordnik.swagger.models.Model> definitions) {
+    private String generateSchema(io.swagger.models.Model model, String modelName, Map<String, io.swagger.models.Model> definitions) {
         return generateSchemaString(model, modelName, definitions);
     }
 
     private Optional<String> getInputModel(BodyParameter p) {
-        com.wordnik.swagger.models.Model model = p.getSchema();
+        io.swagger.models.Model model = p.getSchema();
 
         if (model instanceof RefModel) {
             String modelName = ((RefModel) model).getSimpleRef();   // assumption: complex ref?
@@ -545,14 +545,14 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         cleanupResources(api, basePath, paths);
     }
 
-    private void updateModels(RestApi api, Map<String, com.wordnik.swagger.models.Model> definitions, List<String> apiProduces) {
+    private void updateModels(RestApi api, Map<String, io.swagger.models.Model> definitions, List<String> apiProduces) {
         if (definitions == null) {
             return;
         }
 
-        for (Map.Entry<String, com.wordnik.swagger.models.Model> entry : definitions.entrySet()) {
+        for (Map.Entry<String, io.swagger.models.Model> entry : definitions.entrySet()) {
             final String modelName = entry.getKey();
-            final com.wordnik.swagger.models.Model model = entry.getValue();
+            final io.swagger.models.Model model = entry.getValue();
 
             if (getModel(api, modelName).isPresent()) {
                 updateModel(api, modelName, model);
@@ -564,7 +564,7 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         cleanupModels(api, definitions);
     }
 
-    private void updateModel(RestApi api, String modelName, com.wordnik.swagger.models.Model model) {
+    private void updateModel(RestApi api, String modelName, io.swagger.models.Model model) {
         LOG.info(format("Updating model for api id %s and model name %s", api.getId(), modelName));
         updateModel(api, modelName, generateSchema(model, modelName, swagger.getDefinitions()));
     }
@@ -584,7 +584,7 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         sleep();
     }
 
-    private void cleanupModels(RestApi api, Map<String, com.wordnik.swagger.models.Model> definitions) {
+    private void cleanupModels(RestApi api, Map<String, io.swagger.models.Model> definitions) {
         api.getModels().getItem().stream().filter(model -> !definitions.containsKey(model.getName())).forEach(model -> {
             LOG.info("Removing deleted model " + model.getName());
             try {


### PR DESCRIPTION
updating just the swagger-core isn't enough, as old swagger references exist as transitive dependencies. The package structure changed, hence the changes in multiple files.
