### PR TITLE
Added option to create/update an API using its name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# maven
+build
+
+# intellij files
+.idea
+*.iml
+*.iws
+*.ipr

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ e.g. `./aws-api-import.sh --create path/to/swagger.json`
 
 e.g. `./aws-api-import.sh --update API_ID --deploy STAGE_NAME path/to/swagger.yaml`
 
+#### Create or update an existing API by name.
+
+e.g. `./aws-api-import.sh --create-update --deploy STAGE_NAME path/to/swagger.yaml`
+
+Note: AWS allows multiple APIs to be created with the same name. This option will pick the first one in the order provided by AWS.
+
 ### API Gateway Swagger Extension Example
 
 You can fully define an API Gateway API in Swagger using the x-amazon-apigateway-auth and x-amazon-apigateway-integration extensions.

--- a/src/com/amazonaws/service/apigateway/importer/ApiFileImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/ApiFileImporter.java
@@ -18,6 +18,7 @@ package com.amazonaws.service.apigateway.importer;
 public interface ApiFileImporter {
     String importApi(String filePath);
     void updateApi(String apiId, String filePath);
+    String createOrUpdateApi(String filePath);
     void deploy(String apiId, String deploymentStage);
     void deleteApi(String apiId);
 }

--- a/src/com/amazonaws/service/apigateway/importer/ApiImporterMain.java
+++ b/src/com/amazonaws/service/apigateway/importer/ApiImporterMain.java
@@ -42,6 +42,9 @@ public class ApiImporterMain {
     @Parameter(names = {"--create", "-c"}, description = "Create a new API")
     private boolean createNew;
 
+    @Parameter(names = {"--create-update", "-a"}, description = "Create a new API or update existing one based on API title")
+    private boolean createOrUpdate;
+
     @Parameter(description = "Path to API definition file to import")
     private List<String> files;
 
@@ -97,7 +100,9 @@ public class ApiImporterMain {
 
             String swaggerFile = files.get(0);
 
-            if (createNew) {
+            if (createOrUpdate) {
+                apiId = importer.createOrUpdateApi(swaggerFile);
+            } else if (createNew) {
                 apiId = importer.importApi(swaggerFile);
 
                 if (cleanup) {
@@ -117,7 +122,7 @@ public class ApiImporterMain {
     }
 
     private boolean validateArgs() {
-        if ((apiId == null && !createNew) || files == null || files.isEmpty()) {
+        if ((apiId == null && !createNew && !createOrUpdate) || files == null || files.isEmpty()) {
             return false;
         }
 

--- a/src/com/amazonaws/service/apigateway/importer/SwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/SwaggerApiImporter.java
@@ -19,6 +19,7 @@ import com.wordnik.swagger.models.Swagger;
 public interface SwaggerApiImporter {
     String createApi(Swagger swagger, String name);
     void updateApi(String apiId, Swagger swagger);
+    String createOrUpdateApi(Swagger swagger, String defaultApiName);
     void deploy(String apiId, String deploymentStage);
     void deleteApi(String apiId);
 }

--- a/src/com/amazonaws/service/apigateway/importer/impl/ApiGatewaySwaggerFileImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/ApiGatewaySwaggerFileImporter.java
@@ -59,6 +59,16 @@ public class ApiGatewaySwaggerFileImporter implements ApiFileImporter {
     }
 
     @Override
+    public String createOrUpdateApi(String filePath) {
+        LOG.info(format("Attempting to create API from Swagger definition. " +
+            "Swagger file: %s", filePath));
+
+        final Swagger swagger = parse(filePath);
+
+        return client.createOrUpdateApi(swagger, new File(filePath).getName());
+    }
+
+    @Override
     public void deploy(String apiId, String deploymentStage) {
         client.deploy(apiId, deploymentStage);
     }

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import javax.swing.text.html.Option;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -157,12 +158,15 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
     private Optional<RestApi> getApiByName(String apiName) {
         List<RestApi> restApis = apiGateway.getRestApis().getItem();
 
-			RestApi matchedRestApi = restApis.stream()
-					.filter(restApi -> restApi.getName().equals(apiName))
-					.collect(Collectors.toList())
-					.get(0);
+        List<RestApi> matchingApis = restApis.stream()
+            .filter(restApi -> restApi.getName().equals(apiName))
+            .collect(Collectors.toList());
 
-			return Optional.ofNullable(matchedRestApi);
+        if (matchingApis != null && !matchingApis.isEmpty()) {
+            return Optional.ofNullable(matchingApis.get(0));
+        }
+
+			  return Optional.empty();
 		}
 
     private Resource createResource(RestApi api, String parentResourceId, String pathPart) {


### PR DESCRIPTION
This is to allow automatic creation/update and deployment of an API.

This allows us to:
1. Create an API if it doesn't exist.
2. Update an API if it already exists.
3. Not maintain the API ID. Since, having multiple APIs with same name is a scenario, I am not sure, how many people will want.
4. Only need a Swagger file.
5. Easy to automate in CI.
