### PR TITLE
Adding ability to set configuration on stage via a new extension

### DIFF
--- a/aws-api-import.cmd
+++ b/aws-api-import.cmd
@@ -1,1 +1,1 @@
-java -jar build/maven/aws-apigateway-swagger-importer-1.0.0-jar-with-dependencies.jar %*
+java -jar build/maven/aws-apigateway-swagger-importer-1.0.1-jar-with-dependencies.jar %*

--- a/aws-api-import.sh
+++ b/aws-api-import.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -jar build/maven/aws-apigateway-swagger-importer-1.0.0-jar-with-dependencies.jar "$@"
+java -jar build/maven/aws-apigateway-swagger-importer-1.0.1-jar-with-dependencies.jar "$@"

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
@@ -250,6 +250,11 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
                     getStringValue(methodSetting.getCacheTtlInSeconds())));
         }
 
+        if (getStringValue(methodSetting.getCachingEnabled()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/caching/enabled",
+                    getStringValue(methodSetting.getCachingEnabled())));
+        }
+
         if (getStringValue(methodSetting.getCacheDataEncrypted()) != null) {
             patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/caching/dataEncrypted",
                     getStringValue(methodSetting.getCacheDataEncrypted())));

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
@@ -17,17 +17,21 @@ package com.amazonaws.service.apigateway.importer.impl.sdk;
 import com.amazonaws.service.apigateway.importer.SwaggerApiImporter;
 import com.amazonaws.service.apigateway.importer.impl.SchemaTransformer;
 import com.amazonaws.services.apigateway.model.ApiGateway;
+import com.amazonaws.services.apigateway.model.CacheClusterSize;
 import com.amazonaws.services.apigateway.model.CreateDeploymentInput;
 import com.amazonaws.services.apigateway.model.CreateModelInput;
 import com.amazonaws.services.apigateway.model.CreateResourceInput;
 import com.amazonaws.services.apigateway.model.CreateRestApiInput;
+import com.amazonaws.services.apigateway.model.Deployment;
 import com.amazonaws.services.apigateway.model.Integration;
 import com.amazonaws.services.apigateway.model.IntegrationType;
 import com.amazonaws.services.apigateway.model.Method;
 import com.amazonaws.services.apigateway.model.MethodResponse;
+import com.amazonaws.services.apigateway.model.MethodSetting;
 import com.amazonaws.services.apigateway.model.Model;
 import com.amazonaws.services.apigateway.model.Models;
 import com.amazonaws.services.apigateway.model.PatchDocument;
+import com.amazonaws.services.apigateway.model.PatchOperation;
 import com.amazonaws.services.apigateway.model.PutIntegrationInput;
 import com.amazonaws.services.apigateway.model.PutIntegrationResponseInput;
 import com.amazonaws.services.apigateway.model.PutMethodInput;
@@ -35,6 +39,7 @@ import com.amazonaws.services.apigateway.model.PutMethodResponseInput;
 import com.amazonaws.services.apigateway.model.Resource;
 import com.amazonaws.services.apigateway.model.Resources;
 import com.amazonaws.services.apigateway.model.RestApi;
+import com.amazonaws.services.apigateway.model.Stage;
 import com.google.inject.Inject;
 import com.wordnik.swagger.models.Operation;
 import com.wordnik.swagger.models.Path;
@@ -75,6 +80,7 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
     private static final String DEFAULT_PRODUCES_CONTENT_TYPE = "application/json";
     private static final String EXTENSION_AUTH = "x-amazon-apigateway-auth";
     private static final String EXTENSION_INTEGRATION = "x-amazon-apigateway-integration";
+    private static final String EXTENSION_STAGE = "x-amazon-apigateway-stage";
 
     @Inject
     private ApiGateway apiGateway;
@@ -118,7 +124,44 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         CreateDeploymentInput input = new CreateDeploymentInput();
         input.setStageName(deploymentStage);
 
-        apiGateway.getRestApiById(apiId).createDeployment(input);
+        HashMap<String, HashMap> stageExt =
+                (HashMap<String, HashMap>) swagger.getInfo().getVendorExtensions().get(EXTENSION_STAGE);
+
+        if (stageExt != null) {
+            if (getStringValue(stageExt.get("cacheEnabled")) != null) {
+                input.setCacheClusterEnabled(Boolean.valueOf(getStringValue(stageExt.get("cacheEnabled"))));
+            }
+
+            if (getStringValue(stageExt.get("cacheSize")) != null) {
+                input.setCacheClusterSize(CacheClusterSize.fromValue(getStringValue(stageExt.get("cacheSize"))));
+            }
+        }
+
+        Deployment deployment = null;
+        try {
+             deployment = apiGateway.getRestApiById(apiId).createDeployment(input);
+        } catch (Throwable t) {
+            LOG.error("Error deploying API, rolling back", t);
+            if (deployment.getStages() != null && deployment.getStages().getStageByName(deploymentStage) != null)
+            deployment.getStages().getStageByName(deploymentStage).deleteStage();
+            deployment.deleteDeployment();
+            throw t;
+        }
+
+        Stage stage = deployment.getStages().getStageByName(deploymentStage);
+        try {
+            if (stageExt != null) {
+                // method settings at this level apply to all methods
+                updateStageMethodSetting(stage, swagger.getInfo().getVendorExtensions(), "*/*");
+            }
+
+            // update the stage with individual method overrides
+            updateStageMethodSettings(stage, swagger.getPaths());
+        } catch (Throwable t) {
+            LOG.error("Error updating stage after deployment, rolling back stage", t);
+            stage.deleteStage();
+            throw t;
+        }
     }
 
     @Override
@@ -156,6 +199,95 @@ public class ApiGatewaySdkSwaggerApiImporter implements SwaggerApiImporter {
         Resource resource = api.getResourceById(parentResourceId);
 
         return resource.createResource(input);
+    }
+
+    private Stage updateStageMethodSettings(Stage stage, Map<String, Path> paths) {
+        for(Map.Entry<String, Path> entry : paths.entrySet()) {
+            final Map<String, Operation> ops = getOperations(entry.getValue());
+            for (Map.Entry<String, Operation> subEntry : ops.entrySet()) {
+                updateStageMethodSetting(stage, subEntry.getValue().getVendorExtensions(),
+                        generateMethodSettingKey(subEntry.getKey(), entry.getKey()));
+            }
+        }
+        return stage;
+    }
+
+    private void updateStageMethodSetting(Stage stage, Map<String, Object> vendorExtensions, String methodSettingKey) {
+        MethodSetting methodSetting = getMethodSettingFromExtension(vendorExtensions);
+        if (methodSetting == null) {
+            return;
+        }
+        LOG.info("Updating stage '" + stage.getStageName() + "' method settings for method '" + methodSettingKey + "'");
+        List<PatchOperation> patchOperations = new ArrayList<>();
+
+        if (getStringValue(methodSetting.getMetricsEnabled()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/metrics/enabled",
+                    getStringValue(methodSetting.getMetricsEnabled())));
+        }
+
+        if (getStringValue(methodSetting.getThrottlingBurstLimit()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/throttling/burstLimit",
+                    getStringValue(methodSetting.getThrottlingBurstLimit())));
+        }
+
+        if (getStringValue(methodSetting.getThrottlingRateLimit()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/throttling/rateLimit",
+                    getStringValue(methodSetting.getThrottlingRateLimit())));
+        }
+
+        if (getStringValue(methodSetting.getLoggingLevel()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/logging/loglevel",
+                    getStringValue(methodSetting.getLoggingLevel())));
+        }
+
+        if (getStringValue(methodSetting.getDataTraceEnabled()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/logging/dataTrace",
+                    getStringValue(methodSetting.getDataTraceEnabled())));
+        }
+
+        if (getStringValue(methodSetting.getCacheTtlInSeconds()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/caching/ttlInSeconds",
+                    getStringValue(methodSetting.getCacheTtlInSeconds())));
+        }
+
+        if (getStringValue(methodSetting.getCacheDataEncrypted()) != null) {
+            patchOperations.add(createReplaceOperation("/" + methodSettingKey + "/caching/dataEncrypted",
+                    getStringValue(methodSetting.getCacheDataEncrypted())));
+        }
+
+        PatchDocument pd = createPatchDocument(patchOperations.toArray(new PatchOperation[patchOperations.size()]));
+
+        stage.updateStage(pd);
+    }
+
+    private MethodSetting getMethodSettingFromExtension(Map<String, Object> vendorExtensions) {
+        HashMap<String, HashMap> stageExt =
+                (HashMap<String, HashMap>) vendorExtensions.get(EXTENSION_STAGE);
+        if (stageExt == null) {
+            return null;
+        }
+        HashMap<String, String> methodSettings = stageExt.get("methodSettings");
+        if (methodSettings == null) {
+            return null;
+        }
+
+        MethodSetting methodSetting = new MethodSetting();
+        methodSetting.withCacheTtlInSeconds(getStringValue(methodSettings.get("cacheTtlInSeconds")) != null ?
+                Integer.valueOf(getStringValue(methodSettings.get("cacheTtlInSeconds"))) : null);
+        methodSetting.withCacheDataEncrypted(Boolean.valueOf(getStringValue(methodSettings.get("cacheDataEncrypted"))));
+        methodSetting.setMetricsEnabled(Boolean.valueOf(getStringValue(methodSettings.get("metricsEnabled"))));
+        methodSetting.setThrottlingBurstLimit(getStringValue(methodSettings.get("throttlingBurstLimit")) != null ?
+                Integer.valueOf(getStringValue(methodSettings.get("throttlingBurstLimit"))) : null);
+        methodSetting.setThrottlingRateLimit(getStringValue(methodSettings.get("throttlingRateLimit")) != null ?
+                Double.valueOf(getStringValue(methodSettings.get("throttlingRateLimit"))) : null);
+        methodSetting.setLoggingLevel(getStringValue(methodSettings.get("loggingLevel")));
+        methodSetting.setDataTraceEnabled(Boolean.valueOf(getStringValue(methodSettings.get("dataTraceEnabled"))));
+        methodSetting.setCachingEnabled(Boolean.valueOf(getStringValue(methodSettings.get("cachingEnabled"))));
+        return methodSetting;
+    }
+
+    private String generateMethodSettingKey(String operationType, String path) {
+        return path.replaceAll("/", "~1") + "/" + operationType.toUpperCase();
     }
 
     private void createModel(RestApi api, String modelName, String description, String schema, String modelContentType) {

--- a/tst/resources/apigateway-with-stage-extensions.json
+++ b/tst/resources/apigateway-with-stage-extensions.json
@@ -1,0 +1,363 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "API Gateway Test API",
+        "description": "Move your app forward with the Uber API",
+        "version": "1.0.0",
+        "x-amazon-apigateway-stage": {
+            "cacheSize": "0.5",
+            "cacheEnabled": "true",
+            "methodSettings": {
+                "metricsEnabled": "true",
+                "throttlingBurstLimit": "1000",
+                "loggingLevel": "INFO",
+                "cachingEnabled": "true",
+                "dataTraceEnabled": "true",
+                "throttlingRateLimit": "500",
+                "cacheTtlInSeconds": "14400",
+                "cacheDataEncrypted": "false"
+            }
+        }
+    },
+    "host": "api.uber.com",
+    "schemes": [
+        "https"
+    ],
+    "basePath": "/v1",
+    "produces": [
+        "application/json"
+    ],
+    "security" : [{
+        "api_key" : []
+    }],
+    "securityDefinitions" : {
+        "api_key": {
+            "type": "apiKey",
+            "name": "x-api-key",
+            "in": "header"
+        }
+    },
+    "paths": {
+        "/products": {
+            "get": {
+                "summary": "Product Types",
+                "description": "The Products endpoint returns information about the *Uber* products\noffered at a given location. The response includes the display name\nand other details about each product, and lists the products in the\nproper display order.\n",
+                "parameters": [
+                    {
+                        "name": "latitude",
+                        "in": "query",
+                        "description": "Latitude component of location.",
+                        "required": true,
+                        "type": "number",
+                        "format": "double"
+                    },
+                    {
+                        "name": "longitude",
+                        "in": "query",
+                        "description": "Longitude component of location.",
+                        "required": true,
+                        "type": "number",
+                        "format": "double"
+                    }
+                ],
+                "tags": [
+                    "Products"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "An array of products",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Product"
+                            }
+                        },
+                        "headers" : {
+                            "test-method-response-header" : {
+                                "type" : "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                },
+                "security" : [{
+                    "api_key" : []
+                }],
+                "x-amazon-apigateway-auth" : {
+                    "type" : "aws_iam"
+                },
+                "x-amazon-apigateway-integration" : {
+                    "type" : "aws",
+                    "uri" : "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:ACCOUNT_ID:function:myFunction/invocations",
+                    "httpMethod" : "POST",
+                    "credentials" : "arn:aws:iam::ACCOUNT_ID:role/lambda_exec_role",
+                    "requestTemplates" : {
+                        "application/json" : "json request template 2",
+                        "application/xml" : "xml request template 2"
+                    },
+                    "requestParameters" : {
+                        "integration.request.path.integrationPathParam" : "method.request.querystring.latitude",
+                        "integration.request.querystring.integrationQueryParam" : "method.request.querystring.longitude"
+                    },
+                    "cacheNamespace" : "cache namespace",
+                    "cacheKeyParameters" : [],
+                    "responses" : {
+                        "2\\d{2}" : {
+                            "statusCode" : "200",
+                            "responseParameters" : {
+                                "method.response.header.test-method-response-header" : "integration.response.header.integrationResponseHeaderParam1"
+                            },
+                            "responseTemplates" : {
+                                "application/json" : "json 200 response template",
+                                "application/xml" : "xml 200 response template"
+                            }
+                        },
+                        "default" : {
+                            "statusCode" : "400",
+                            "responseParameters" : {
+                                "method.response.header.test-method-response-header" : "'static value'"
+                            },
+                            "responseTemplates" : {
+                                "application/json" : "json 400 response template",
+                                "application/xml" : "xml 400 response template"
+                            }
+                        }
+                    }
+                },
+                "x-amazon-apigateway-stage": {
+                    "methodSettings": {
+                        "metricsEnabled": "true",
+                        "throttlingBurstLimit": "1000",
+                        "loggingLevel": "INFO",
+                        "cachingEnabled": "true",
+                        "dataTraceEnabled": "true",
+                        "throttlingRateLimit": "500",
+                        "cacheTtlInSeconds": "14400",
+                        "cacheDataEncrypted": "false"
+                    }
+                }
+            }
+        },
+        "/products/child": {
+            "post": {
+                "summary": "Product Types",
+                "description": "The Products endpoint returns information about the *Uber* products\noffered at a given location. The response includes the display name\nand other details about each product, and lists the products in the\nproper display order.\n",
+                "parameters": [
+                    {
+                        "name": "latitude",
+                        "in": "query",
+                        "description": "Latitude component of location.",
+                        "required": true,
+                        "type": "number",
+                        "format": "double"
+                    },
+                    {
+                        "name": "longitude",
+                        "in": "query",
+                        "description": "Longitude component of location.",
+                        "required": true,
+                        "type": "number",
+                        "format": "double"
+                    }
+                ],
+                "tags": [
+                    "Products"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "An array of products",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Product"
+                            }
+                        },
+                        "headers" : {
+                            "test-method-response-header" : {
+                                "type" : "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                },
+                "security" : [{
+                    "api_key" : []
+                }],
+                "x-amazon-apigateway-auth" : {
+                    "type" : "none"
+                },
+                "x-amazon-apigateway-integration" : {
+                    "type" : "http",
+                    "uri" : "https://api.github.com",
+                    "httpMethod" : "GET",
+                    "responses" : {
+                        "2//d{2}" : {
+                            "statusCode" : "200"
+                        },
+                        "default" : {
+                            "statusCode" : "400",
+                            "responseParameters" : {
+                                "method.response.header.test-method-response-header" : "'static value'"
+                            },
+                            "responseTemplates" : {
+                                "application/json" : "json 400 response template",
+                                "application/xml" : "xml 400 response template"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Product": {
+            "properties": {
+                "product_id": {
+                    "type": "string",
+                    "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Description of product."
+                },
+                "display_name": {
+                    "type": "string",
+                    "description": "Display name of product."
+                },
+                "capacity": {
+                    "type": "string",
+                    "description": "Capacity of product. For example, 4 people."
+                },
+                "image": {
+                    "type": "string",
+                    "description": "Image URL representing the product."
+                }
+            }
+        },
+        "PriceEstimate": {
+            "properties": {
+                "product_id": {
+                    "type": "string",
+                    "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles"
+                },
+                "currency_code": {
+                    "type": "string",
+                    "description": "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code."
+                },
+                "display_name": {
+                    "type": "string",
+                    "description": "Display name of product."
+                },
+                "estimate": {
+                    "type": "string",
+                    "description": "Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or \"Metered\" for TAXI."
+                },
+                "low_estimate": {
+                    "type": "number",
+                    "description": "Lower bound of the estimated price."
+                },
+                "high_estimate": {
+                    "type": "number",
+                    "description": "Upper bound of the estimated price."
+                },
+                "surge_multiplier": {
+                    "type": "number",
+                    "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier."
+                }
+            }
+        },
+        "Profile": {
+            "properties": {
+                "first_name": {
+                    "type": "string",
+                    "description": "First name of the Uber user."
+                },
+                "last_name": {
+                    "type": "string",
+                    "description": "Last name of the Uber user."
+                },
+                "email": {
+                    "type": "string",
+                    "description": "Email address of the Uber user"
+                },
+                "picture": {
+                    "type": "string",
+                    "description": "Image URL of the Uber user."
+                },
+                "promo_code": {
+                    "type": "string",
+                    "description": "Promo code of the Uber user."
+                }
+            }
+        },
+        "Activity": {
+            "properties": {
+                "uuid": {
+                    "type": "string",
+                    "description": "Unique identifier for the activity"
+                }
+            }
+        },
+        "Activities": {
+            "properties": {
+                "offset": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Position in pagination."
+                },
+                "limit": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Number of items to retrieve (100 max)."
+                },
+                "count": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Total number of items available."
+                },
+                "history": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Activity"
+                    }
+                }
+            }
+        },
+        "Error": {
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "fields": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We needed the ability to configure the Stage settings during a deployment, so I propose adding an extension to do so:

``` javascript
"x-amazon-apigateway-stage": {
    "cacheSize": "0.5",
    "cacheEnabled": "true",
    "methodSettings": {
        "metricsEnabled": "true",
        "throttlingBurstLimit": "1000",
        "loggingLevel": "INFO",
        "cachingEnabled": "true",
        "dataTraceEnabled": "true",
        "throttlingRateLimit": "500",
        "cacheTtlInSeconds": "14400",
        "cacheDataEncrypted": "false"
    }
}
```

This can be set at the Info level, as well as at the Operation level. In the example .json file I provided, I do not set the 'cacheSize' or 'cacheEnabled' fields at the Operation level, because those values don't really make sense there.
