### PR TITLE
Fix invalid http status regex setting

### DIFF
--- a/tst/resources/apigateway.json
+++ b/tst/resources/apigateway.json
@@ -187,7 +187,7 @@
                     "uri" : "https://api.github.com",
                     "httpMethod" : "GET",
                     "responses" : {
-                        "2//d{2}" : {
+                        "2\\d{2}" : {
                             "statusCode" : "200"
                         },
                         "default" : {


### PR DESCRIPTION
Fixes issue #39

A json file contains invalid http status regex `2//d{2}`
