### PR TITLE
Added model name null checking

### DIFF
--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
@@ -533,7 +533,10 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         }
 
         try {
-            return Optional.of(api.getModelByName(modelName));
+            Model model = api.getModelByName(modelName);
+            if (model.getName() != null) {
+                return Optional.of(model);
+            }
         } catch (Exception ignored) {}
 
         return Optional.empty();


### PR DESCRIPTION
To enable API creation without response body definition (e.g. 302 Found), I added model name null check whether an method has an assured model.
## Details

By API Gateway, I want to create an method which sends [302 Found](https://en.wikipedia.org/wiki/HTTP_302) status for performing URL redirection.  
Since redirection response sends a URL in the "Location" header field (without response body), I define a swagger specification (in YAML format) as follows:

``` yaml
swagger: '2.0'
info:
  title: XXX API
  description: XXX API
  version: 1.0.0
host: myhost.com
schemes:
  - https
basePath: /api
produces:
  - application/json
paths:
  /my/api
    get:
      summary: a summary
      description: a description
      responses:
        '302':
          description: Redirect to other URL
          headers:
            Location:
              type: string
        '400':
          description: Client error
          schema:
            $ref: '#/definitions/Error'
        '500':
          description: Server error
          schema:
            $ref: '#/definitions/Error'
      x-amazon-apigateway-auth:
        type: none
      x-amazon-apigateway-integration:
        type: http
        uri: https://xxx/path
        httpMethod: GET
        requestParameters:
        responses:
          3\d{2}:
            statusCode: '302'
            responseParameters:
              method.response.header.Location: integration.response.header.Location
          4\d{2}:
            statusCode: '400'
          default:
            statusCode: '500'
definitions:
  Error:
    type: object
    properties:
      timestamp:
        type: integer
        format: int64
      status:
        type: integer
        format: int32
        description: HTTP status
      message:
        type: string
        description: error description
```

Then I got following errors (api id is masked):

```
015-10-21 21:18:08,215 INFO - Creating integration with type HTTP
2015-10-21 21:18:09,226 INFO - Creating method for api id ********** and resource id ********** with method get
2015-10-21 21:18:09,596 INFO - Found reference to existing model null
2015-10-21 21:18:09,816 ERROR - Error creating API, rolling back
com.amazonaws.services.apigateway.model.BadRequestException: Invalid model name specified: application/json=null (Service: null; Status Code: 400; Error Code: null; Request ID: cab3e63c-77ed-11e5-828e-bd6a9374997a)
    at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1219)
    at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:803)
    at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:505)
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:317)
    at com.amazonaws.hal.client.HalClient.invoke(HalClient.java:235)
    at com.amazonaws.hal.client.HalClient.putResource(HalClient.java:122)
    at com.amazonaws.hal.client.HalResourceInvocationHandler.invoke(HalResourceInvocationHandler.java:125)
    at com.sun.proxy.$Proxy35.putMethodResponse(Unknown Source)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.lambda$createMethodResponses$13(ApiGatewaySdkSwaggerApiImporter.java:725)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter$$Lambda$8/691779749.accept(Unknown Source)
    at java.util.LinkedHashMap$LinkedEntrySet.forEach(LinkedHashMap.java:663)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createMethodResponses(ApiGatewaySdkSwaggerApiImporter.java:718)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createMethod(ApiGatewaySdkSwaggerApiImporter.java:381)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.lambda$createMethods$1(ApiGatewaySdkSwaggerApiImporter.java:295)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter$$Lambda$5/2021053848.accept(Unknown Source)
    at java.util.HashMap$EntrySet.forEach(HashMap.java:1035)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createMethods(ApiGatewaySdkSwaggerApiImport:294)va
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createResources(ApiGatewaySdkSwaggerApiImporter.java:261)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createApi(ApiGatewaySdkSwaggerApiImporter.java:93)
    at com.amazonaws.service.apigateway.importer.impl.ApiGatewaySwaggerFileImporter.importApi(ApiGatewaySwaggerFileImporter.java:48)
    at com.amazonaws.service.apigateway.importer.ApiImporterMain.execute(ApiImporterMain.java:101)
    at com.amazonaws.service.apigateway.importer.ApiImporterMain.main(ApiImporterMain.java:65)
2015-10-21 21:18:09,818 INFO - Deleting API **********
2015-10-21 21:18:10,973 ERROR - Error importing API from Swagger
com.amazonaws.services.apigateway.model.BadRequestException: Invalid model name specified: application/json=null (Service: null; Status Code: 400; Error Code: null; Request ID: cab3e63c-77ed-11e5-828e-bd6a9374997a)
    at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1219)
    at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:803)
    at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:505)
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:317)
    at com.amazonaws.hal.client.HalClient.invoke(HalClient.java:235)
    at com.amazonaws.hal.client.HalClient.putResource(HalClient.java:122)
    at com.amazonaws.hal.client.HalResourceInvocationHandler.invoke(HalResourceInvocationHandler.java:125)
    at com.sun.proxy.$Proxy35.putMethodResponse(Unknown Source)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.lambda$createMethodResponses$13(ApiGatewaySdkSwaggerApiImporter.java:725)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter$$Lambda$8/691779749.accept(Unknown Source)
    at java.util.LinkedHashMap$LinkedEntrySet.forEach(LinkedHashMap.java:663)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createMethodResponses(ApiGatewaySdkSwaggerApiImporter.java:718)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createMethod(ApiGatewaySdkSwaggerApiImporter.java:381)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.lambda$createMethods$1(ApiGatewaySdkSwaggerApiImporter.java:295)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter$$Lambda$5/2021053848.accept(Unknown Source)
    at java.util.HashMap$EntrySet.forEach(HashMap.java:1035)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createMethods(ApiGatewaySdkSwaggerApiImport:294)va
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createResources(ApiGatewaySdkSwaggerApiImporter.java:261)
    at com.amazonaws.service.apigateway.importer.impl.sdk.ApiGatewaySdkSwaggerApiImporter.createApi(ApiGatewaySdkSwaggerApiImporter.java:93)
    at com.amazonaws.service.apigateway.importer.impl.ApiGatewaySwaggerFileImporter.importApi(ApiGatewaySwaggerFileImporter.java:48)
    at com.amazonaws.service.apigateway.importer.ApiImporterMain.execute(ApiImporterMain.java:101)
    at com.amazonaws.service.apigateway.importer.ApiImporterMain.main(ApiImporterMain.java:65)
:api:create FAILED
```

By applying this commit, the above API was successfully imporeted.
