### PR TITLE
make scripts runnable from other locations

### DIFF
--- a/aws-api-import.cmd
+++ b/aws-api-import.cmd
@@ -1,1 +1,1 @@
-java -jar target/aws-apigateway-importer-1.0.3-SNAPSHOT-jar-with-dependencies.jar  %*
+java -jar %~dp0target/aws-apigateway-importer-1.0.3-SNAPSHOT-jar-with-dependencies.jar  %*

--- a/aws-api-import.sh
+++ b/aws-api-import.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+root=$(dirname "$(readlink -f "$0")")
 
-java -jar target/aws-apigateway-importer-1.0.3-SNAPSHOT-jar-with-dependencies.jar "$@"
+java -jar $root/target/aws-apigateway-importer-1.0.3-SNAPSHOT-jar-with-dependencies.jar "$@"


### PR DESCRIPTION
As it stands, these scripts can only be run from the root of the aws-apigateway-importer tree. This change makes them runnable from any location, making it easier to have the tool "installed" but useable when working with other repos.
