### PR TITLE
Update aws-api-import.sh to work on non-GNU

### DIFF
--- a/aws-api-import.sh
+++ b/aws-api-import.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-root=$(dirname "$(readlink -f "$0")")
+root=$(dirname $(perl -MCwd=abs_path -e 'print abs_path(shift)' $0))
 
 java -jar $root/target/aws-apigateway-importer-1.0.3-SNAPSHOT-jar-with-dependencies.jar "$@"


### PR DESCRIPTION
`readlink -f` is specific to GNU coreutils and generates messages like this on Mac OS X:

```
 $ ./src/aws-apigateway-importer/aws-api-import.sh
 readlink: illegal option -- f
 usage: readlink [-n] [file ...]
 Error: Unable to access jarfile ./target/aws-apigateway-importer-1.0.3-SNAPSHOT-jar-with-dependencies.jar
```

Instead we use perl, which is pretty much guaranteed to be installed everywhere.
