### PR TITLE
Fix docker build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ COPY tst /app/tst/
 WORKDIR /app
 
 RUN mvn assembly:assembly \
-    && mv build/maven/aws-apigateway-*-jar-with-dependencies.jar /aws-apigateway-importer.jar \
-    && mvn clean \
-    && rm -rf /app ~/.m2
+    && mv target/aws-apigateway-*-jar-with-dependencies.jar /aws-apigateway-importer.jar \
+    && mvn clean
 
 VOLUME ["/root/.aws"]
 VOLUME ["/data"]


### PR DESCRIPTION
I ran into a couple of issues trying to run a `docker build` on this repo. Here are some fixes which should get it back to working:
- Change build artifact directory from build/maven to target/ :
  `docker builds` fail at `mv build/maven/aws-apigateway-*-jar-with-dependencies.jar /aws-apigateway-importer.jar` because maven is building into `target/` instead.
- Do not attempt to remove `/root/.m2`:
  The Maven Docker image exports `/root/.m2` so `rm -rf ~/.m2` fails. See
  https://github.com/carlossg/docker-maven/blob/8ab542b907e69c5269942bcc0915d8dffcc7e9fa/jdk-8/Dockerfile#L11 for reference.

Thanks for making this!
