### PR TITLE
squid:S1172 - Unused method parameters should be removed

### DIFF
--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkApiImporter.java
@@ -168,7 +168,7 @@ public class ApiGatewaySdkApiImporter {
         });
     }
 
-    protected Optional<Resource> getResource(RestApi api, String parentResourceId, String pathPart, List<Resource> resources) {
+    protected Optional<Resource> getResource(String parentResourceId, String pathPart, List<Resource> resources) {
         for (Resource r : resources) {
             if (pathEquals(pathPart, r.getPathPart()) && r.getParentId().equals(parentResourceId)) {
                 return Optional.of(r);
@@ -239,7 +239,7 @@ public class ApiGatewaySdkApiImporter {
     }
 
     protected Resource createResource(RestApi api, String parentResourceId, String part, List<Resource> resources) {
-        final Optional<Resource> existingResource = getResource(api, parentResourceId, part, resources);
+        final Optional<Resource> existingResource = getResource(parentResourceId, part, resources);
 
         // create resource if doesn't exist
         if (!existingResource.isPresent()) {

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkRamlApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkRamlApiImporter.java
@@ -185,11 +185,11 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
 
         if (update) {
-            cleanupMethods(api, resource, actions);
+            cleanupMethods(resource, actions);
         }
     }
 
-    private void cleanupMethods (RestApi api, Resource resource, Map<ActionType, Action> actions) {
+    private void cleanupMethods (Resource resource, Map<ActionType, Action> actions) {
         final HashSet<String> methods = new HashSet<>();
 
         for (ActionType action : actions.keySet()) {
@@ -232,7 +232,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
                 }
             }
 
-            cleanupMethodModels(api, method, action.getBody());
+            cleanupMethodModels(method, action.getBody());
         } else {
             LOG.info(format("Creating method for api id %s and resource id %s with method %s", api.getId(), resource.getId(), httpMethod));
 
@@ -270,9 +270,9 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
 
         if (update) {
-            cleanupMethod(api, method, "path", action.getResource().getUriParameters().keySet());
-            cleanupMethod(api, method, "header", action.getHeaders().keySet());
-            cleanupMethod(api, method, "querystring", action.getQueryParameters().keySet());
+            cleanupMethod(method, "path", action.getResource().getUriParameters().keySet());
+            cleanupMethod(method, "header", action.getHeaders().keySet());
+            cleanupMethod(method, "querystring", action.getQueryParameters().keySet());
         }
 
         createIntegration(resource, method, this.config);
@@ -374,7 +374,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         return map;
     }
 
-    private void cleanupMethodModels(RestApi api, Method method, Map<String, MimeType> body) {
+    private void cleanupMethodModels(Method method, Map<String, MimeType> body) {
         if (method.getRequestModels() != null) {
             for (Map.Entry<String, String> entry : method.getRequestModels().entrySet()) {
                 if (!body.containsKey(entry.getKey()) || body.get(entry.getKey()).getSchema() == null) {
@@ -386,7 +386,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private void cleanupMethod(RestApi api, Method method, String type, Set<String> parameterSet) {
+    private void cleanupMethod(Method method, String type, Set<String> parameterSet) {
         if (method.getRequestParameters() != null) {
             method.getRequestParameters().keySet().forEach(key -> {
                 final String[] parts = key.split("\\.");
@@ -400,7 +400,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private String generateModelName(MimeType mimeType) {
+    private String generateModelName() {
         return "model" + UUID.randomUUID().toString().substring(0, 8);
     }
 
@@ -410,11 +410,11 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
 
         if (update) {
-            cleanupMethodResponses(api, method, responses);
+            cleanupMethodResponses(method, responses);
         }
     }
 
-    private void cleanupMethodResponses(RestApi api, Method method, Map<String, Response> responses) {
+    private void cleanupMethodResponses(Method method, Map<String, Response> responses) {
         method.getMethodResponses().entrySet().forEach(entry -> {
             if (!responses.containsKey(entry.getKey())) {
                 entry.getValue().deleteMethodResponse();
@@ -462,7 +462,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
                 return schema;
             }
 
-            final String modelName = generateModelName(mimeType);
+            final String modelName = generateModelName();
 
             models.add(modelName);
             createModel(api, modelName, null, schema, mime);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1172 - Unused method parameters should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1172
Please let me know if you have any questions.
George Kankava
