### PR TITLE
squid:S2325 - "private" methods that don't access instance data should be "static"

### DIFF
--- a/src/com/amazonaws/service/apigateway/importer/impl/SchemaTransformer.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/SchemaTransformer.java
@@ -47,7 +47,7 @@ public class SchemaTransformer {
         return getFlattened(deserialize(model), deserialize(models));
     }
 
-    private void buildSchemaReferenceMap(JsonNode model, JsonNode models, Map<String, String> modelMap) {
+    private static void buildSchemaReferenceMap(JsonNode model, JsonNode models, Map<String, String> modelMap) {
         Map<JsonNode, JsonNode> refs = new HashMap<>();
         findReferences(model, refs);
 
@@ -67,7 +67,7 @@ public class SchemaTransformer {
         }
     }
 
-    private JsonNode getSchema(String schemaName, JsonNode models) {
+    private static JsonNode getSchema(String schemaName, JsonNode models) {
         return models.findPath(schemaName);
     }
 
@@ -91,7 +91,7 @@ public class SchemaTransformer {
         return flattened;
     }
 
-    private void validate(JsonNode rootNode) {
+    private static void validate(JsonNode rootNode) {
         final JsonSchemaFactory factory;
         try {
             factory = JsonSchemaFactory.byDefault();
@@ -126,14 +126,14 @@ public class SchemaTransformer {
     /*
      * Replace a reference node with an inline reference
      */
-    private void replaceRef(ObjectNode parent, String schemaName) {
+    private static void replaceRef(ObjectNode parent, String schemaName) {
         parent.set("$ref", new TextNode("#/definitions/" + schemaName));
     }
 
     /*
      * Find all reference node in the schema tree. Build a map of the reference node to its parent
      */
-    private void findReferences(JsonNode node, Map<JsonNode, JsonNode> refNodes) {
+    private static void findReferences(JsonNode node, Map<JsonNode, JsonNode> refNodes) {
         JsonNode refNode = node.path("$ref");
         if (!refNode.isMissingNode()) {
             refNodes.put(refNode, node);
@@ -161,7 +161,7 @@ public class SchemaTransformer {
      * Attempt to serialize an existing schema
      * If this fails something is seriously wrong, because this schema has already been saved by the control plane
      */
-    private String serializeExisting(JsonNode root) {
+    private static String serializeExisting(JsonNode root) {
         try {
             return new ObjectMapper().writeValueAsString(root);
         } catch (JsonProcessingException e) {

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkApiImporter.java
@@ -234,7 +234,7 @@ public class ApiGatewaySdkApiImporter {
         return result;
     }
 
-    private String trimSlashes(String path) {
+    private static String trimSlashes(String path) {
         return StringUtils.removeEnd(StringUtils.removeStart(path, "/"), "/");
     }
 

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkRamlApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkRamlApiImporter.java
@@ -105,7 +105,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         cleanupModels(api, this.models);
     }
 
-    private String getApiName (Raml raml, String fileName) {
+    private static String getApiName (Raml raml, String fileName) {
         String title = raml.getTitle();
         return StringUtils.isNotBlank(title) ? title : fileName;
     }
@@ -189,7 +189,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private void cleanupMethods (RestApi api, Resource resource, Map<ActionType, Action> actions) {
+    private static void cleanupMethods (RestApi api, Resource resource, Map<ActionType, Action> actions) {
         final HashSet<String> methods = new HashSet<>();
 
         for (ActionType action : actions.keySet()) {
@@ -280,7 +280,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         createMethodResponses(api, method, action.getResponses(), update);
     }
 
-    private void createIntegration(Resource resource, Method method, JSONObject config) {
+    private static void createIntegration(Resource resource, Method method, JSONObject config) {
         if (config == null) {
             return;
         }
@@ -312,7 +312,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private void createIntegrationResponses(Integration integration, JSONObject responses) {
+    private static void createIntegrationResponses(Integration integration, JSONObject responses) {
         if (responses == null) {
             return;
         }
@@ -339,7 +339,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private List<String> jsonObjectToListString (JSONArray json) {
+    private static List<String> jsonObjectToListString (JSONArray json) {
         if (json == null) {
           return null;
         }
@@ -355,7 +355,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         return list;
     }
 
-    private Map<String, String> jsonObjectToHashMapString (JSONObject json) {
+    private static Map<String, String> jsonObjectToHashMapString (JSONObject json) {
         if (json == null) {
           return null;
         }
@@ -400,7 +400,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private String generateModelName(MimeType mimeType) {
+    private static String generateModelName(MimeType mimeType) {
         return "model" + UUID.randomUUID().toString().substring(0, 8);
     }
 
@@ -473,7 +473,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         return null;
     }
 
-    private String getExpression(String area, String part, String type, String name) {
+    private static String getExpression(String area, String part, String type, String name) {
         return area + "." + part + "." + type + "." + name;
     }
 
@@ -492,7 +492,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         method.updateMethod(createPatchDocument(createAddOperation("/requestParameters/" + expression, getStringValue(required))));
     }
 
-    private String getAuthorizationTypeFromConfig(Resource resource, String method, JSONObject config) {
+    private static String getAuthorizationTypeFromConfig(Resource resource, String method, JSONObject config) {
         if (config == null) {
             return "NONE";
         }
@@ -508,7 +508,7 @@ public class ApiGatewaySdkRamlApiImporter extends ApiGatewaySdkApiImporter imple
         }
     }
 
-    private String escapeOperationString(String value) {
+    private static String escapeOperationString(String value) {
         return value.replaceAll("~", "~0").replaceAll("/", "~1");
     }
 

--- a/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
+++ b/src/com/amazonaws/service/apigateway/importer/impl/sdk/ApiGatewaySdkSwaggerApiImporter.java
@@ -92,7 +92,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         cleanupModels(api, this.processedModels);
     }
 
-    private String getApiName(Swagger swagger, String fileName) {
+    private static String getApiName(Swagger swagger, String fileName) {
         String title = swagger.getInfo().getTitle();
         return StringUtils.isNotBlank(title) ? title : fileName;
     }
@@ -182,7 +182,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         });
     }
 
-    private Map<String, Operation> getOperations(Path path) {
+    private static Map<String, Operation> getOperations(Path path) {
         final Map<String, Operation> ops = new HashMap<>();
 
         addOp(ops, "get", path.getGet());
@@ -195,7 +195,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         return ops;
     }
 
-    private void addOp(Map<String, Operation> ops, String method, Operation operation) {
+    private static void addOp(Map<String, Operation> ops, String method, Operation operation) {
         if (operation != null) {
             ops.put(method, operation);
         }
@@ -287,7 +287,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         });
     }
 
-    private String getAuthorizationType(Operation op) {
+    private static String getAuthorizationType(Operation op) {
         String authType = "NONE";
         if (op.getVendorExtensions() != null) {
             HashMap<String, String> authExtension = (HashMap<String, String>) op.getVendorExtensions().get(EXTENSION_AUTH);
@@ -346,7 +346,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         return generateSchemaString(model, modelName, definitions);
     }
 
-    private Optional<String> getInputModel(BodyParameter p) {
+    private static Optional<String> getInputModel(BodyParameter p) {
         com.wordnik.swagger.models.Model model = p.getSchema();
 
         if (model instanceof RefModel) {
@@ -361,7 +361,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         return generateModelName(response.getDescription());
     }
 
-    private String generateModelName(String description) {
+    private static String generateModelName(String description) {
         if (StringUtils.isBlank(description)) {
             LOG.warn("No description found for model, will generate a unique model name");
             return "model" + UUID.randomUUID().toString().substring(0, 8);
@@ -371,11 +371,11 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         return description.replaceAll(getModelNameSanitizeRegex(), "");
     }
 
-    private String generateModelName(BodyParameter param) {
+    private static String generateModelName(BodyParameter param) {
         return generateModelName(param.getDescription());
     }
 
-    private String getModelNameSanitizeRegex() {
+    private static String getModelNameSanitizeRegex() {
         return "[^A-Za-z0-9]";
     }
 
@@ -452,7 +452,7 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         cleanupResources(api, buildResourceSet(paths.keySet(), basePath));
     }
 
-    private Set<String> buildResourceSet(Set<String> paths, String basePath) {
+    private static Set<String> buildResourceSet(Set<String> paths, String basePath) {
         if (StringUtils.isBlank(basePath)) {
             basePath = "/";
         }
@@ -557,12 +557,12 @@ public class ApiGatewaySdkSwaggerApiImporter extends ApiGatewaySdkApiImporter im
         });
     }
 
-    private String createRequestParameterExpression(Parameter p) {
+    private static String createRequestParameterExpression(Parameter p) {
         Optional<String> loc = getParameterLocation(p);
         return "method.request." + loc.get() + "." + p.getName();
     }
 
-    private Optional<String> getParameterLocation(Parameter p) {
+    private static Optional<String> getParameterLocation(Parameter p) {
         switch (p.getIn()) {
             case "path":
                 return Optional.of("path");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava
