### PR TITLE
Pin aws-sdk-java-core for JSONObject compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>[1.8.6,2.0)</version>
+            <version>[1.8.6,1.10.77)</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The latest version of `aws-sdk-java-core` removes JSONObject in favor of Jackson (https://github.com/aws/aws-sdk-java/commit/b26560b306d1e0fd1eea7843032d0a51d75a9aa7). This breaks builds of aws-apigateway-importer since it depends on `JSONObject`. Locking to version `1.10.77` until aws-apigateway-importer can be updated fixes builds.

Fixes #192 
